### PR TITLE
Fix dropped covariates / polynomials passing through model.matrix

### DIFF
--- a/R/continuous_wrap.R
+++ b/R/continuous_wrap.R
@@ -38,6 +38,11 @@ continuous_wrap <- function(df_trans, var_interest, model,
   # calculate predictions
   preds <- sapply(cov_preds, function(x){ mean(x$pred_resp) })
 
+  # if covariates are dropped from the model, remove those columns from cov_preds
+  for(i in 1:length(cov_preds)){
+    cov_preds[[i]]$covar <- cov_preds[[i]]$covar[, !is.na(coef(model))]
+  }
+
   # calculate jacobian
   jacobs <- do.call(rbind, lapply(cov_preds, function(x){
     if(type == 'levels'){

--- a/R/discrete_wrap.R
+++ b/R/discrete_wrap.R
@@ -45,6 +45,11 @@ discrete_wrap <- function(df_trans, var_interest, model,
       deriv_func = model$family$mu.eta)
   }))
 
+  # if covariates are dropped from the model, remove those columns from cov_preds
+  for(i in 1:length(cov_preds)){
+    cov_preds[[i]]$covar <- cov_preds[[i]]$covar[, !is.na(coef(model))]
+  }
+
   if(type == 'effects'){
     jacobs <- discrete_effect_jacob(jacobs, base_rn)
     preds <- discrete_effect_pred(preds, base_rn)

--- a/R/mod_marg.R
+++ b/R/mod_marg.R
@@ -32,7 +32,7 @@ mod_marg2 <- function(mod, var_interest,
   stopifnot(
     'glm' %in% class(mod),
     var_interest %in% names(mod$model),
-    all(names(at) %in% names(mod$model))
+    all(names(at) %in% names(mod$data))
     # TODO: warning if at contains extrapolated values
     )
   if( any(grepl('factor', attr(terms(mod$formula), 'term.labels'))) )

--- a/R/predict_modelmat.R
+++ b/R/predict_modelmat.R
@@ -23,8 +23,10 @@
 predict_modelmat <- function(model, transformed_df,
                              formula = model$formula){
 
+  m <- model.frame(formula, transformed_df, xlev = model$xlevels)
+
   list(
-    covar =  model.matrix(formula, transformed_df),
+    covar =  model.matrix(formula, m, contrasts.arg = model$contrasts),
     pred_link = predict(model, newdata = transformed_df),
     pred_resp = predict(model, newdata = transformed_df, type = 'response')
   )


### PR DESCRIPTION
Note: my original code was branched off of dev2 and this MR required removing lines 31-33 of data_clean.R from the model_frame branch (https://github.com/anniejw6/modmarg/pull/16/files#diff-e1a9c960b95672c0236e52c40e0f54f2R31). This branch is designed to work with `poly()`, that branch with `I(covar^2)`, so if we merge both this branch and model_frame as written, neither will work right.