### PR TITLE
add data as a param

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: modmarg
 Title: Calculating Marginal Effects and Levels with Errors
-Version: 0.1.0
+Version: 0.2.0
 Authors@R: c(
 	person("Alex", "Gold", email = "alex.k.gold@gmail.com", role = "aut"),
 	person("Nat", "Olin", email = "nathaniel.olin@gmail.com", role = c("ctb")),

--- a/man/mod_marg2.Rd
+++ b/man/mod_marg2.Rd
@@ -5,7 +5,7 @@
 \title{Estimating predictive margins on a model}
 \usage{
 mod_marg2(mod, var_interest, type = "levels", vcov_mat = vcov(mod),
-  at = NULL, base_rn = 1, at_var_interest = NULL)
+  at = NULL, base_rn = 1, at_var_interest = NULL, data = mod$data)
 }
 \arguments{
 \item{mod}{model object, currently only support those of class glm}
@@ -25,6 +25,8 @@ Defaults to 1.}
 
 \item{at_var_interest}{vector, if type == 'levels', the values for the variable of interest at which levels should be calculated.
 If NULL, indicates all levels for a factor variable, defaults to NULL}
+
+\item{data}{data.frame that margins should run over, defaults to mod$data}
 }
 \value{
 list of dataframes with predicted margins/effects, se, p-values, and confidence interval bounds

--- a/tests/testthat/test_overall.R
+++ b/tests/testthat/test_overall.R
@@ -288,11 +288,9 @@ test_that("mod_marg2 subsets of data run properly", {
   z1 <- mod_marg2(mod = mm, var_interest = 'treatment',
                   type = "levels",
                   data = subset(margex, agegroup == "20-29"))
-
   z2 <- mod_marg2(mod = mm, var_interest = 'treatment',
                   type = "levels",
                   data = subset(margex, agegroup == "30-39"))
-
   z3 <- mod_marg2(mod = mm, var_interest = 'treatment',
                   type = "levels",
                   data = subset(margex, agegroup == "40+"))
@@ -300,14 +298,16 @@ test_that("mod_marg2 subsets of data run properly", {
   expect_equal(z1[[1]]$Margin, c(68.67471, 83.40595), tolerance = 0.0001)
   expect_equal(z1[[1]]$Standard.Error, c(0.8908722, 1.3643423),
                tolerance = 0.0001)
-
   expect_equal(z2[[1]]$Margin, c(67.23932, 79.75863), tolerance = 0.0001)
   expect_equal(z2[[1]]$Standard.Error, c(1.004951, 1.164683),
                tolerance = 0.0001)
-
   expect_equal(z3[[1]]$Margin, c(58.87818, 71.36229), tolerance = 0.0001)
   expect_equal(z3[[1]]$Standard.Error, c(0.8580671, 0.6532233),
                tolerance = 0.0001)
+
+  expect_error(mod_marg2(mod = mm, var_interest = 'treatment',
+                         type = 'levels',
+                         data = margex[, names(margex) != 'distance']))
 
 })
 


### PR DESCRIPTION
Turns out, we shouldn't actually have removed the data parameter because when we run subgroups, we often subset the data over which we calculate margins.

@nathanielolin to add more tests.