### PR TITLE
test for base_rn and warning with levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: modmarg
 Title: Calculating Marginal Effects and Levels with Errors
-Version: 0.3.3
+Version: 0.3.1
 Authors@R: c(
 	person("Alex", "Gold", email = "alex.k.gold@gmail.com", role = "aut"),
 	person("Nat", "Olin", email = "nathaniel.olin@gmail.com", role = c("ctb")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: modmarg
 Title: Calculating Marginal Effects and Levels with Errors
-Version: 0.3.0
+Version: 0.3.3
 Authors@R: c(
 	person("Alex", "Gold", email = "alex.k.gold@gmail.com", role = "aut"),
 	person("Nat", "Olin", email = "nathaniel.olin@gmail.com", role = c("ctb")),

--- a/R/mod_marg.R
+++ b/R/mod_marg.R
@@ -99,6 +99,10 @@ mod_marg2 <- function(mod, var_interest,
                       names(at)[i]))
   }
 
+  # Warn if base_rn set but type != 'effects'
+  if(base_rn != 1 & type != 'effects')
+    warning(paste("Setting base_rn when type == 'levels' is ignored."))
+
   # Transform the ats ---
   if(!is.null(at)){
 

--- a/tests/testthat/test_overall.R
+++ b/tests/testthat/test_overall.R
@@ -328,7 +328,7 @@ test_that("mod_marg2 input is checked", {
 
 test_that("Setting base level works", {
 
-  # extrapolated values are troubling
+  data(margex)
   mm <- glm(y ~ as.factor(treatment) + age, margex, family = 'gaussian')
 
   # Setting base_rn without type = 'effects' does nothing (warning)
@@ -343,12 +343,33 @@ test_that("Setting base level works", {
                   at = list(age = 50), base_rn = 2,
                   type = 'effects')[[1]]
 
+  # stata
+  # margins, dydx(treatment)
+  #
+  # Average marginal effects                          Number of obs   =       3000
+  # Model VCE    : OLS
+  #
+  # Expression   : Linear prediction, predict()
+  # dy/dx w.r.t. : treatment
+  #
+  # ------------------------------------------------------------------------------
+  #              |            Delta-method
+  #              |      dy/dx   Std. Err.      t    P>|t|     [95% Conf. Interval]
+  # -------------+----------------------------------------------------------------
+  #    treatment |   14.03271   .7777377    18.04   0.000     12.50775    15.55766
+  # ------------------------------------------------------------------------------
+
   # Make sure effects flipped right
-  expect_equal(z1$Margin, rev(-1 * z2$Margin))
-  expect_equal(z1$Standard.Error, rev(z2$Standard.Error))
-  expect_equal(z1$Test.Stat, rev(-1 * z2$Test.Stat))
-  expect_equal(z1$P.Value, rev(z2$P.Value))
-  expect_equal(z1$`Lower CI (95%)`, rev(-1 * z2$`Upper CI (95%)`))
-  expect_equal(z1$`Upper CI (95%)`, rev(-1 * z2$`Lower CI (95%)`))
+  expect_equal(z1$Margin, rev(-1 * z2$Margin), c(0, 14.03271),
+               tolerance = 0.0001)
+  expect_equal(z1$Standard.Error, rev(z2$Standard.Error), c(0, .7777377),
+               tolerance = 0.0001)
+  expect_equal(z1$Test.Stat, rev(-1 * z2$Test.Stat), c(NaN, 18.04),
+               tolerance = 0.01)
+  expect_equal(z1$P.Value, rev(z2$P.Value), 0.000, tolerance = 0.001)
+  expect_equal(z1$`Lower CI (95%)`, rev(-1 * z2$`Upper CI (95%)`),
+               c(0, 12.50775), tolerance = 0.0001)
+  expect_equal(z1$`Upper CI (95%)`, rev(-1 * z2$`Lower CI (95%)`),
+               c(0, 15.55766), tolerance = 0.0001)
 
 })

--- a/tests/testthat/test_overall.R
+++ b/tests/testthat/test_overall.R
@@ -326,3 +326,29 @@ test_that("mod_marg2 input is checked", {
                            at = list(age = 100)))
 })
 
+test_that("Setting base level works", {
+
+  # extrapolated values are troubling
+  mm <- glm(y ~ as.factor(treatment) + age, margex, family = 'gaussian')
+
+  # Setting base_rn without type = 'effects' does nothing (warning)
+  expect_warning(mod_marg2(mod = mm, var_interest = 'treatment',
+                           at = list(age = 50), base_rn = 2))
+
+  # Actual check
+  z1 <- mod_marg2(mod = mm, var_interest = 'treatment',
+                  at = list(age = 50), base_rn = 1,
+                  type = 'effects')[[1]]
+  z2 <- mod_marg2(mod = mm, var_interest = 'treatment',
+                  at = list(age = 50), base_rn = 2,
+                  type = 'effects')[[1]]
+
+  # Make sure effects flipped right
+  expect_equal(z1$Margin, rev(-1 * z2$Margin))
+  expect_equal(z1$Standard.Error, rev(z2$Standard.Error))
+  expect_equal(z1$Test.Stat, rev(-1 * z2$Test.Stat))
+  expect_equal(z1$P.Value, rev(z2$P.Value))
+  expect_equal(z1$`Lower CI (95%)`, rev(-1 * z2$`Upper CI (95%)`))
+  expect_equal(z1$`Upper CI (95%)`, rev(-1 * z2$`Lower CI (95%)`))
+
+})


### PR DESCRIPTION
Warns if `base_rn != 1 & type != 'effects'`, added test that `base_rn = 2` works appropriately. Might need to redo version numbers depending on the order things are merged. Addresses issue #60 