### PR TITLE
Update testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: modmarg
 Title: Calculating Marginal Effects and Levels with Errors
-Version: 0.8.0
+Version: 0.8.1
 Authors@R: c(
 	person("Alex", "Gold", email = "alex.k.gold@gmail.com", role = "aut"),
 	person("Nat", "Olin", email = "nathaniel.olin@gmail.com", role = c("ctb")),
@@ -22,4 +22,4 @@ Suggests:
     testthat,
     sandwich
 VignetteBuilder: knitr
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/tests/testthat/test_overall.R
+++ b/tests/testthat/test_overall.R
@@ -27,18 +27,32 @@ test_that("levels are calculated correctly despite different input types", {
   z3 <- marg(mod3, var_interest = 'treatment',
                   type = 'levels', at = NULL)[[1]]
 
-  expect_equal(z1$Margin, z2$Margin, z3$Margin, c(.0791146, .2600204),
+  expect_equal(z1$Margin, expected = c(.0791146, .2600204),
                tolerance = 0.0001)
-  expect_equal(z1$Standard.Error, z2$Standard.Error, z3$Standard.Error,
-               c(.0069456, .0111772), tolerance = 0.0001)
-  expect_equal(z1$Test.Stat, z2$Test.Stat, z3$Test.Stat,
-               c(11.39, 23.26), tolerance = 0.001)
-  expect_equal(z1$P.Value, z2$P.Value, z3$P.Value,
-               c(0, 0), tolerance = 0.001)
-  expect_equal(z1$`Lower CI (95%)`, z2$`Lower CI (95%)`, z3$`Lower CI (95%)`,
-               c(.0655016, .2381135), tolerance = 0.0001)
-  expect_equal(z1$`Upper CI (95%)`, z2$`Upper CI (95%)`, z3$`Upper CI (95%)`,
-               c(.0927277, .2819272), tolerance = 0.0001)
+  expect_equal(z2$Margin, expected = c(.0791146, .2600204),
+               tolerance = 0.0001)
+  expect_equal(z3$Margin, expected = c(.0791146, .2600204),
+               tolerance = 0.0001)
+
+  expect_equal(z1$Standard.Error, c(.0069456, .0111772), tolerance = 0.0001)
+  expect_equal(z2$Standard.Error, c(.0069456, .0111772), tolerance = 0.0001)
+  expect_equal(z3$Standard.Error, c(.0069456, .0111772), tolerance = 0.0001)
+
+  expect_equal(z1$Test.Stat, c(11.39, 23.26), tolerance = 0.001)
+  expect_equal(z2$Test.Stat, c(11.39, 23.26), tolerance = 0.001)
+  expect_equal(z3$Test.Stat, c(11.39, 23.26), tolerance = 0.001)
+
+  expect_equal(z1$P.Value, c(0, 0), tolerance = 0.001)
+  expect_equal(z2$P.Value, c(0, 0), tolerance = 0.001)
+  expect_equal(z3$P.Value, c(0, 0), tolerance = 0.001)
+
+  expect_equal(z1$`Lower CI (95%)`, c(.0655016, .2381135), tolerance = 0.0001)
+  expect_equal(z2$`Lower CI (95%)`, c(.0655016, .2381135), tolerance = 0.0001)
+  expect_equal(z3$`Lower CI (95%)`, c(.0655016, .2381135), tolerance = 0.0001)
+
+  expect_equal(z1$`Upper CI (95%)`, c(.0927277, .2819272), tolerance = 0.0001)
+  expect_equal(z2$`Upper CI (95%)`, c(.0927277, .2819272), tolerance = 0.0001)
+  expect_equal(z3$`Upper CI (95%)`, c(.0927277, .2819272), tolerance = 0.0001)
 
 })
 
@@ -70,18 +84,29 @@ test_that("effects are calculated correctly despite different input types", {
                   type = 'effects', at = NULL)[[1]]
   z3 <- z3[2, ]
 
-  expect_equal(z1$Margin, z2$Margin, z3$Margin,
-               c(.1809057), tolerance = 0.0001)
-  expect_equal(z1$Standard.Error, z2$Standard.Error, z3$Standard.Error,
-               c(.0131684), tolerance = 0.0001)
-  expect_equal(z1$Test.Stat, z2$Test.Stat, z3$Test.Stat,
-               c(13.74), tolerance = 0.001)
-  expect_equal(z1$P.Value, z2$P.Value, z3$P.Value,
-               c(0), tolerance = 0.001)
-  expect_equal(z1$`Lower CI (95%)`, z2$`Lower CI (95%)`, z3$`Lower CI (95%)`,
-               c(.1550961), tolerance = 0.0001)
-  expect_equal(z1$`Upper CI (95%)`, z2$`Upper CI (95%)`, z3$`Upper CI (95%)`,
-               c(.2067153), tolerance = 0.0001)
+  expect_equal(z1$Margin, c(.1809057), tolerance = 0.0001)
+  expect_equal(z2$Margin, c(.1809057), tolerance = 0.0001)
+  expect_equal(z3$Margin, c(.1809057), tolerance = 0.0001)
+
+  expect_equal(z1$Standard.Error, c(.0131684), tolerance = 0.0001)
+  expect_equal(z2$Standard.Error, c(.0131684), tolerance = 0.0001)
+  expect_equal(z3$Standard.Error, c(.0131684), tolerance = 0.0001)
+
+  expect_equal(z1$Test.Stat, c(13.74), tolerance = 0.001)
+  expect_equal(z2$Test.Stat, c(13.74), tolerance = 0.001)
+  expect_equal(z3$Test.Stat, c(13.74), tolerance = 0.001)
+
+  expect_equal(z1$P.Value, c(0), tolerance = 0.001)
+  expect_equal(z2$P.Value, c(0), tolerance = 0.001)
+  expect_equal(z3$P.Value, c(0), tolerance = 0.001)
+
+  expect_equal(z1$`Lower CI (95%)`, c(.1550961), tolerance = 0.0001)
+  expect_equal(z2$`Lower CI (95%)`, c(.1550961), tolerance = 0.0001)
+  expect_equal(z3$`Lower CI (95%)`, c(.1550961), tolerance = 0.0001)
+
+  expect_equal(z1$`Upper CI (95%)`, c(.2067153), tolerance = 0.0001)
+  expect_equal(z2$`Upper CI (95%)`, c(.2067153), tolerance = 0.0001)
+  expect_equal(z3$`Upper CI (95%)`, c(.2067153), tolerance = 0.0001)
 
 })
 
@@ -381,17 +406,23 @@ test_that("Setting base level works", {
   # ------------------------------------------------------------------------------
 
   # Make sure effects flipped right
-  expect_equal(z1$Margin, rev(-1 * z2$Margin), c(0, 14.03271),
-               tolerance = 0.0001)
-  expect_equal(z1$Standard.Error, rev(z2$Standard.Error), c(0, .7777377),
-               tolerance = 0.0001)
-  expect_equal(z1$Test.Stat, rev(-1 * z2$Test.Stat), c(NaN, 18.04),
-               tolerance = 0.01)
-  expect_equal(z1$P.Value, rev(z2$P.Value), 0.000, tolerance = 0.001)
-  expect_equal(z1$`Lower CI (95%)`, rev(-1 * z2$`Upper CI (95%)`),
-               c(0, 12.50775), tolerance = 0.0001)
-  expect_equal(z1$`Upper CI (95%)`, rev(-1 * z2$`Lower CI (95%)`),
-               c(0, 15.55766), tolerance = 0.0001)
+  expect_equal(z1$Margin, c(0, 14.03271), tolerance = 0.0001)
+  expect_equal(rev(-1 * z2$Margin), c(0, 14.03271), tolerance = 0.0001)
+
+  expect_equal(z1$Standard.Error, c(0, .7777377), tolerance = 0.0001)
+  expect_equal(rev(z2$Standard.Error), c(0, .7777377), tolerance = 0.0001)
+
+  expect_equal(z1$Test.Stat, c(NaN, 18.04), tolerance = 0.01)
+  expect_equal(rev(-1 * z2$Test.Stat), c(NaN, 18.04), tolerance = 0.01)
+
+  expect_equal(z1$P.Value, c(NA, 0.000), tolerance = 0.001)
+  expect_equal(rev(z2$P.Value), c(NA, 0.000), tolerance = 0.001)
+
+  expect_equal(z1$`Lower CI (95%)`, c(0, 12.50775), tolerance = 0.0001)
+  expect_equal(rev(-1 * z2$`Upper CI (95%)`), c(0, 12.50775), tolerance = 0.0001)
+
+  expect_equal(z1$`Upper CI (95%)`, c(0, 15.55766), tolerance = 0.0001)
+  expect_equal(rev(-1 * z2$`Lower CI (95%)`), c(0, 15.55766), tolerance = 0.0001)
 
   # . reg y ib2.group##c.distance
   #

--- a/tests/testthat/test_overall.R
+++ b/tests/testthat/test_overall.R
@@ -27,12 +27,9 @@ test_that("levels are calculated correctly despite different input types", {
   z3 <- marg(mod3, var_interest = 'treatment',
                   type = 'levels', at = NULL)[[1]]
 
-  expect_equal(z1$Margin, expected = c(.0791146, .2600204),
-               tolerance = 0.0001)
-  expect_equal(z2$Margin, expected = c(.0791146, .2600204),
-               tolerance = 0.0001)
-  expect_equal(z3$Margin, expected = c(.0791146, .2600204),
-               tolerance = 0.0001)
+  expect_equal(z1$Margin, c(.0791146, .2600204), tolerance = 0.0001)
+  expect_equal(z2$Margin, c(.0791146, .2600204), tolerance = 0.0001)
+  expect_equal(z3$Margin, c(.0791146, .2600204), tolerance = 0.0001)
 
   expect_equal(z1$Standard.Error, c(.0069456, .0111772), tolerance = 0.0001)
   expect_equal(z2$Standard.Error, c(.0069456, .0111772), tolerance = 0.0001)
@@ -415,8 +412,8 @@ test_that("Setting base level works", {
   expect_equal(z1$Test.Stat, c(NaN, 18.04), tolerance = 0.01)
   expect_equal(rev(-1 * z2$Test.Stat), c(NaN, 18.04), tolerance = 0.01)
 
-  expect_equal(z1$P.Value, c(NA, 0.000), tolerance = 0.001)
-  expect_equal(rev(z2$P.Value), c(NA, 0.000), tolerance = 0.001)
+  expect_equal(z1$P.Value, c(NaN, 0.000), tolerance = 0.001)
+  expect_equal(rev(z2$P.Value), c(NaN, 0.000), tolerance = 0.001)
 
   expect_equal(z1$`Lower CI (95%)`, c(0, 12.50775), tolerance = 0.0001)
   expect_equal(rev(-1 * z2$`Upper CI (95%)`), c(0, 12.50775), tolerance = 0.0001)


### PR DESCRIPTION
Updates to `testthat` package for version 2.0 means `...` is passed to `all.equal`, and we can't test equality of multiple objects at once anymore.

Tested locally with dev version installed: `devtools::install_github("r-lib/testthat")`