### PR TITLE
Check formula

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: modmarg
 Title: Calculating Marginal Effects and Levels with Errors
-Version: 0.9.2
+Version: 0.9.3
 Authors@R: c(
 	person("Alex", "Gold", email = "alex.k.gold@gmail.com", role = "aut"),
 	person("Nat", "Olin", email = "nathaniel.olin@gmail.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,4 +23,4 @@ Suggests:
     sandwich,
     AER
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/R/data_clean.R
+++ b/R/data_clean.R
@@ -82,9 +82,6 @@ gen_at_list <- function(df, var_interest, at_var_interest = NULL){
 handle_missing <- function(model, data, weights, nrow_orig){
 
   # Add weights
-  if('_weights' %in% all.vars(model$formula))
-    stop("You cannot use the name '_weights' in the model formula. ",
-         "Please rename to another variable.")
   if(is.null(weights)) weights <- rep(1, nrow_orig)
 
   # Keep completes only

--- a/R/marg.R
+++ b/R/marg.R
@@ -84,6 +84,10 @@ marg <- function(mod, var_interest, data = NULL,
                   at_var_interest = NULL,  at = NULL,
                   cofint = 0.95, ...){
 
+  # If mod$formula is a string, the error message is deeply uninformative
+  if(! "formula" %in% class(mod$formula))
+    stop("Estimate your model with a formula object, not a character string.")
+
   # Check arguments ---
   stopifnot(type %in% c('levels', 'effects'),
             is.numeric(cofint),

--- a/man/marg.glm.Rd
+++ b/man/marg.glm.Rd
@@ -5,8 +5,8 @@
 \title{Predicted Margins for `glm` objects}
 \usage{
 \method{marg}{glm}(mod, var_interest,
-  data = mod$data[names(mod$prior.weights), ], weights = mod$prior.weights,
-  ...)
+  data = mod$data[names(mod$prior.weights), ],
+  weights = mod$prior.weights, ...)
 }
 \arguments{
 \item{mod}{model object, currently only support those of class \code{\link[stats]{glm}}

--- a/tests/testthat/test_glm.R
+++ b/tests/testthat/test_glm.R
@@ -341,7 +341,14 @@ test_that("marg input is checked", {
   # lm should fail
   margex$sex <- factor(margex$sex)
   ml <- lm(y ~ sex + age, margex)
-  expect_error(marg(mod = lm, var_interest = 'sex'))
+  expect_error(marg(mod = ml, var_interest = 'sex'),
+               "no applicable method for 'marg' applied to an object of class \"lm\"",
+               fixed = T)
+
+  # string formulas shouldn't work
+  mm <- glm('y ~ sex + age', margex, family = 'gaussian')
+  expect_error(marg(mod = mm, var_interest = 'sex'),
+               regexp = "Estimate your model with a formula object, not a character string.")
 
   # extrapolated values are troubling
   mm <- glm(y ~ sex + age, margex, family = 'gaussian')


### PR DESCRIPTION
Adds input check for `mod$formula`, because `glm` objects can be fit with strings as the formula, but the resulting model object has a string which then breaks deep into `marg` with an uninformative error.

Also fixes a neighboring test that wasn't testing properly.